### PR TITLE
Handle arrays in rosbag_pandas

### DIFF
--- a/rosbag_pandas.py
+++ b/rosbag_pandas.py
@@ -45,7 +45,7 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
     # create datastore
     datastore = {}
     for topic in dmap.keys():
-        for f, key in dmap[topic].items():
+        for f, key in dmap[topic].iteritems():
             t = msg_type[topic][f]
             if isinstance(t, int) or isinstance(t, float):
                 arr = np.empty(length)
@@ -58,7 +58,7 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
                     datastore[key_i] = arr.copy()
                 continue
             else:
-                arr = np.array([None] * length)
+                arr = np.empty(length, dtype=np.object)
             datastore[key] = arr
 
     # create the index
@@ -66,8 +66,7 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
     index.fill(np.NAN)
 
     # all of the data is loaded
-    idx = 0
-    for topic, msg, mt in bag.read_messages(topics=bag_topics):
+    for idx, (topic, msg, mt) in enumerate(bag.read_messages(topics=bag_topics)):
         try:
             if seconds:
                 index[idx] = msg.header.stamp.to_sec()
@@ -79,7 +78,7 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
             else:
                 index[idx] = mt.to_nsec()
         fields = dmap[topic]
-        for f, key in fields.items():
+        for f, key in fields.iteritems():
             try:
                 d = get_message_data(msg, f)
                 if isinstance(d, tuple):
@@ -90,7 +89,6 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
                     datastore[key][idx] = d
             except:
                 pass
-        idx = idx + 1
 
     bag.close()
 
@@ -281,7 +279,7 @@ def clean_for_export(df):
     new_df = pd.DataFrame()
     for c, t in df.dtypes.iteritems():
         if t.kind in 'OSUV':
-            s =  df[c].dropna().apply(func=str)
+            s = df[c].dropna().apply(func=str)
             s = s.str.replace('\n', '')
             s = s.str.replace('\r', '')
             s = s.str.replace(',','\t')
@@ -292,7 +290,5 @@ def clean_for_export(df):
     return new_df 
 
 
-
-
 if __name__ == '__main__':
-    print 'hello'
+    print('hello')

--- a/rosbag_pandas.py
+++ b/rosbag_pandas.py
@@ -50,6 +50,13 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
             if isinstance(t, int) or isinstance(t, float):
                 arr = np.empty(length)
                 arr.fill(np.NAN)
+            elif isinstance(t, list):
+                arr = np.empty(length)
+                arr.fill(np.NAN)
+                for i in range(len(t)):
+                    key_i = '{0}{1}'.format(key, i)
+                    datastore[key_i] = arr.copy()
+                continue
             else:
                 arr = np.array([None] * length)
             datastore[key] = arr
@@ -75,7 +82,12 @@ def bag_to_dataframe(bag_name, include=None, exclude=None, parse_header=False, s
         for f, key in fields.items():
             try:
                 d = get_message_data(msg, f)
-                datastore[key][idx] = d
+                if isinstance(d, tuple):
+                    for i, val in enumerate(d):
+                        key_i = '{0}{1}'.format(key, i)
+                        datastore[key_i][idx] = val
+                else:
+                    datastore[key][idx] = d
             except:
                 pass
         idx = idx + 1


### PR DESCRIPTION
This PR allows the handling of fixed-length arrays in messages. If a message contains an array, 
```
msg.something = [0, 1]
```
it is converted to 
```
df['something0'] = 0
df['something1'] = 1
```

This frequently occurs in our ROS codebase and it would be great, if this patch could be merged upstream. Thanks.