### PR TITLE
fix missing Loader in yaml.load

### DIFF
--- a/src/rosbag_pandas/rosbag_pandas.py
+++ b/src/rosbag_pandas/rosbag_pandas.py
@@ -212,7 +212,7 @@ def get_bag_info(bag_file):
     # Get the info on the bag
     bag_info = yaml.load(subprocess.Popen(
         ['rosbag', 'info', '--yaml', bag_file],
-        stdout=subprocess.PIPE).communicate()[0])
+        stdout=subprocess.PIPE).communicate()[0], Loader=yaml.FullLoader)
     return bag_info
 
 


### PR DESCRIPTION
This fixes the issues https://github.com/aktaylor08/RosbagPandas/issues/17 and https://github.com/aktaylor08/RosbagPandas/issues/21 by adding the now required Loader argument when using yaml.load().